### PR TITLE
fixed random sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ import numpy
 
 # classifier
 from sklearn.linear_model import LogisticRegression
+
+# utils
+import random
 ```
 
 ### Input Format
@@ -96,7 +99,8 @@ class LabeledLineSentence(object):
         return self.sentences
     
     def sentences_perm(self):
-        return numpy.random.permutation(self.sentences)
+        random.shuffle(self.sentences)
+        return self.sentences
 ```
 
 Now we can feed the data files to `LabeledLineSentence`. As we mentioned earlier, `LabeledLineSentence` simply takes a dictionary with keys as the file names and values the special prefixes for sentences from that document. The prefixes need to be unique, so that there is no ambiguitiy for sentences from different documents.


### PR DESCRIPTION
I had an error with `.setences_perm()`, this PR fixes it.

This error was:

```
 File "/home/local/ANT/tejal/anaconda/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/home/local/ANT/tejal/anaconda/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/local/ANT/tejal/anaconda/lib/python2.7/site-packages/gensim-0.12.0-py2.7-linux-x86_64.egg/gensim/models/word2vec.py", line 675, in worker_loop
    if not worker_one_job(job, init):
  File "/home/local/ANT/tejal/anaconda/lib/python2.7/site-packages/gensim-0.12.0-py2.7-linux-x86_64.egg/gensim/models/word2vec.py", line 666, in worker_one_job
    job_words = self._do_train_job(items, alpha, inits)
  File "/home/local/ANT/tejal/anaconda/lib/python2.7/site-packages/gensim-0.12.0-py2.7-linux-x86_64.egg/gensim/models/doc2vec.py", line 617, in _do_train_job
    indexed_doctags = self.docvecs.indexed_doctags(doc.tags)
AttributeError: 'list' object has no attribute 'tags'
```

This thread suggested using `random.shuffle` instead of `numpy.random.permutation`

https://groups.google.com/forum/#!topic/gensim/e-bxNNTyekA
